### PR TITLE
Removed </html> tag from

### DIFF
--- a/Hacky/Resources/WebViews/comments.html
+++ b/Hacky/Resources/WebViews/comments.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
-<head>
-  <meta charset="utf-8">
-  <title>Comments</title>
-  <link href="css/vendor/normalize.css" rel="stylesheet" type="text/css">
-  <link href="css/comments.css" rel="stylesheet" type="text/css">
-</head>
-<body>
-  <div id="comments"></div>
-  <script type="text/javascript" src="js/vendor/zepto-v1.0rc1.js"></script>
-  <script type="text/javascript" src="js/comments.js"></script>
-</body>
-</html>
+  <head>
+    <meta charset="utf-8">
+    <title>Comments</title>
+    <link href="css/vendor/normalize.css" rel="stylesheet" type="text/css">
+    <link href="css/comments.css" rel="stylesheet" type="text/css">
+  </head>
+  <body>
+    <div id="comments"></div>
+    <script type="text/javascript" src="js/vendor/zepto-v1.0rc1.js"></script>
+    <script type="text/javascript" src="js/comments.js"></script>
+  </body>


### PR DESCRIPTION
comments.html simply didn't need a closing html tag. In HTML 5 all that is needed is the <!DOCTYPE html> tag.